### PR TITLE
feat: 학생 재실 상태 선택 라디오버튼으로 변경

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { GeistSans } from "geist/font/sans"
 import { GeistMono } from "geist/font/mono"
 import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
+import { Toaster } from "sonner"
 import "./globals.css"
 
 export const metadata: Metadata = {
@@ -21,6 +22,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <Suspense fallback={null}>{children}</Suspense>
+        <Toaster position="top-right" richColors />
         <Analytics />
       </body>
     </html>

--- a/components/rollcall/attendance-status-buttons.tsx
+++ b/components/rollcall/attendance-status-buttons.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useState, forwardRef, useMemo } from "react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { Student, Rollcall } from "@/lib/types"
+
+export type AttendanceStatus = "PRESENT" | "OUT" | "LEAVE" | "ABSENT"
+
+interface AttendanceStatusButtonsProps {
+  student: Student
+  rollcall?: Rollcall
+  onStatusChange: (studentId: number, status: AttendanceStatus) => void
+  disabled?: boolean
+  className?: string
+}
+
+const statusConfig = {
+  PRESENT: {
+    label: "재실",
+    variant: "default" as const,
+    className: "bg-green-500 hover:bg-green-600 text-white border-green-500",
+    selectedClassName: "!bg-green-600 !text-white !font-bold !shadow-lg !ring-2 !ring-green-300",
+  },
+  OUT: {
+    label: "외출",
+    variant: "secondary" as const,
+    className: "bg-blue-500 hover:bg-blue-600 text-white border-blue-500",
+    selectedClassName: "!bg-blue-600 !text-white !font-bold !shadow-lg !ring-2 !ring-blue-300",
+  },
+  LEAVE: {
+    label: "외박",
+    variant: "outline" as const,
+    className: "bg-purple-500 hover:bg-purple-600 text-white border-purple-500",
+    selectedClassName: "!bg-purple-600 !text-white !font-bold !shadow-lg !ring-2 !ring-purple-300",
+  },
+  ABSENT: {
+    label: "결석",
+    variant: "destructive" as const,
+    className: "bg-red-500 hover:bg-red-600 text-white border-red-500",
+    selectedClassName: "!bg-red-600 !text-white !font-bold !shadow-lg !ring-2 !ring-red-300",
+  },
+} as const
+
+export const AttendanceStatusButtons = forwardRef<HTMLDivElement, AttendanceStatusButtonsProps>(({
+  student,
+  rollcall,
+  onStatusChange,
+  disabled = false,
+  className,
+}, ref) => {
+  const [isChanging, setIsChanging] = useState(false)
+
+  // 현재 상태 결정: rollcall의 status가 있으면 사용, 없으면 present 기반으로 추론
+  const currentStatus = useMemo((): AttendanceStatus => {
+    console.log("AttendanceStatusButtons currentStatus 계산:", { rollcall, studentId: student.id })
+    if (rollcall?.status) {
+      return rollcall.status
+    }
+    // 기존 present 필드 기반으로 추론
+    return rollcall?.present ? "PRESENT" : "ABSENT"
+  }, [rollcall, student.id])
+
+  const handleStatusChange = async (status: AttendanceStatus) => {
+    if (disabled || isChanging || status === currentStatus) return
+
+    setIsChanging(true)
+    try {
+      onStatusChange(student.id, status)
+    } finally {
+      setIsChanging(false)
+    }
+  }
+
+  console.log("AttendanceStatusButtons 렌더링:", { currentStatus, studentId: student.id, rollcall })
+
+  return (
+    <div ref={ref} className={cn("flex gap-1", className)}>
+      {Object.entries(statusConfig).map(([status, config]) => {
+        const statusKey = status as AttendanceStatus
+        const isSelected = currentStatus === statusKey
+        console.log(`버튼 ${status} (${statusKey}) isSelected:`, isSelected, "currentStatus:", currentStatus)
+        return (
+          <button
+            key={status}
+            type="button"
+            className={cn(
+              "flex-1 text-xs px-2 py-1 h-8 transition-all duration-200 rounded-md border font-medium",
+              config.className,
+              isSelected && config.selectedClassName,
+              disabled && "opacity-50 cursor-not-allowed",
+              isChanging && "opacity-70 cursor-wait",
+              !isSelected && "hover:opacity-80"
+            )}
+            style={isSelected ? {
+              backgroundColor: statusKey === 'PRESENT' ? '#16a34a' : 
+                              statusKey === 'OUT' ? '#2563eb' : 
+                              statusKey === 'LEAVE' ? '#9333ea' : '#dc2626',
+              color: 'white',
+              fontWeight: 'bold',
+              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+              border: `2px solid ${statusKey === 'PRESENT' ? '#22c55e' : 
+                                  statusKey === 'OUT' ? '#3b82f6' : 
+                                  statusKey === 'LEAVE' ? '#a855f7' : '#ef4444'}`
+            } : {}}
+            onClick={() => handleStatusChange(statusKey)}
+            disabled={disabled || isChanging}
+          >
+            {config.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+})
+
+AttendanceStatusButtons.displayName = "AttendanceStatusButtons"

--- a/components/rollcall/attendance-status-buttons.tsx
+++ b/components/rollcall/attendance-status-buttons.tsx
@@ -20,19 +20,19 @@ const statusConfig = {
     label: "재실",
     variant: "default" as const,
     className: "bg-transparent hover:bg-green-50 text-green-600 border-green-500",
-    selectedClassName: "!bg-green-50 !text-green-700 !font-bold !shadow-md !ring-2 !ring-green-300 !border-green-600",
+    selectedClassName: "!bg-gradient-to-br !from-green-50/5 !to-green-50/10 !text-green-700 !font-bold !shadow-md !ring-2 !ring-green-300/40 !border-green-600/80",
   },
   LEAVE: {
     label: "외박",
     variant: "outline" as const,
     className: "bg-transparent hover:bg-yellow-50 text-yellow-600 border-yellow-500",
-    selectedClassName: "!bg-yellow-50 !text-yellow-700 !font-bold !shadow-md !ring-2 !ring-yellow-300 !border-yellow-600",
+    selectedClassName: "!bg-gradient-to-br !from-yellow-50/5 !to-yellow-50/10 !text-yellow-700 !font-bold !shadow-md !ring-2 !ring-yellow-300/40 !border-yellow-600/80",
   },
   ABSENT: {
     label: "결석",
     variant: "destructive" as const,
     className: "bg-transparent hover:bg-red-50 text-red-600 border-red-500",
-    selectedClassName: "!bg-red-50 !text-red-700 !font-bold !shadow-md !ring-2 !ring-red-300 !border-red-600",
+    selectedClassName: "!bg-gradient-to-br !from-red-50/5 !to-red-50/10 !text-red-700 !font-bold !shadow-md !ring-2 !ring-red-300/40 !border-red-600/80",
   },
 } as const
 
@@ -86,16 +86,6 @@ export const AttendanceStatusButtons = forwardRef<HTMLDivElement, AttendanceStat
               isChanging && "opacity-70 cursor-wait",
               !isSelected && "hover:opacity-80"
             )}
-            style={isSelected ? {
-              backgroundColor: statusKey === 'PRESENT' ? '#f0fdf4' : 
-                              statusKey === 'LEAVE' ? '#fefce8' : '#fef2f2',
-              color: statusKey === 'PRESENT' ? '#15803d' : 
-                     statusKey === 'LEAVE' ? '#a16207' : '#dc2626',
-              fontWeight: 'bold',
-              boxShadow: '0 2px 4px -1px rgba(0, 0, 0, 0.1)',
-              border: `2px solid ${statusKey === 'PRESENT' ? '#22c55e' : 
-                                  statusKey === 'LEAVE' ? '#eab308' : '#ef4444'}`
-            } : {}}
             onClick={() => handleStatusChange(statusKey)}
             disabled={disabled || isChanging}
           >

--- a/components/rollcall/attendance-status-buttons.tsx
+++ b/components/rollcall/attendance-status-buttons.tsx
@@ -19,20 +19,20 @@ const statusConfig = {
   PRESENT: {
     label: "재실",
     variant: "default" as const,
-    className: "bg-green-500 hover:bg-green-600 text-white border-green-500",
-    selectedClassName: "!bg-green-600 !text-white !font-bold !shadow-lg !ring-2 !ring-green-300",
+    className: "bg-transparent hover:bg-green-50 text-green-600 border-green-500",
+    selectedClassName: "!bg-green-50 !text-green-700 !font-bold !shadow-md !ring-2 !ring-green-300 !border-green-600",
   },
   LEAVE: {
     label: "외박",
     variant: "outline" as const,
-    className: "bg-yellow-500 hover:bg-yellow-600 text-white border-yellow-500",
-    selectedClassName: "!bg-yellow-600 !text-white !font-bold !shadow-lg !ring-2 !ring-yellow-300",
+    className: "bg-transparent hover:bg-yellow-50 text-yellow-600 border-yellow-500",
+    selectedClassName: "!bg-yellow-50 !text-yellow-700 !font-bold !shadow-md !ring-2 !ring-yellow-300 !border-yellow-600",
   },
   ABSENT: {
     label: "결석",
     variant: "destructive" as const,
-    className: "bg-red-500 hover:bg-red-600 text-white border-red-500",
-    selectedClassName: "!bg-red-600 !text-white !font-bold !shadow-lg !ring-2 !ring-red-300",
+    className: "bg-transparent hover:bg-red-50 text-red-600 border-red-500",
+    selectedClassName: "!bg-red-50 !text-red-700 !font-bold !shadow-md !ring-2 !ring-red-300 !border-red-600",
   },
 } as const
 
@@ -87,13 +87,14 @@ export const AttendanceStatusButtons = forwardRef<HTMLDivElement, AttendanceStat
               !isSelected && "hover:opacity-80"
             )}
             style={isSelected ? {
-              backgroundColor: statusKey === 'PRESENT' ? '#16a34a' : 
-                              statusKey === 'LEAVE' ? '#eab308' : '#dc2626',
-              color: 'white',
+              backgroundColor: statusKey === 'PRESENT' ? '#f0fdf4' : 
+                              statusKey === 'LEAVE' ? '#fefce8' : '#fef2f2',
+              color: statusKey === 'PRESENT' ? '#15803d' : 
+                     statusKey === 'LEAVE' ? '#a16207' : '#dc2626',
               fontWeight: 'bold',
-              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+              boxShadow: '0 2px 4px -1px rgba(0, 0, 0, 0.1)',
               border: `2px solid ${statusKey === 'PRESENT' ? '#22c55e' : 
-                                  statusKey === 'LEAVE' ? '#facc15' : '#ef4444'}`
+                                  statusKey === 'LEAVE' ? '#eab308' : '#ef4444'}`
             } : {}}
             onClick={() => handleStatusChange(statusKey)}
             disabled={disabled || isChanging}

--- a/components/rollcall/attendance-status-buttons.tsx
+++ b/components/rollcall/attendance-status-buttons.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import type { Student, Rollcall } from "@/lib/types"
 
-export type AttendanceStatus = "PRESENT" | "OUT" | "LEAVE" | "ABSENT"
+export type AttendanceStatus = "PRESENT" | "LEAVE" | "ABSENT"
 
 interface AttendanceStatusButtonsProps {
   student: Student
@@ -22,17 +22,11 @@ const statusConfig = {
     className: "bg-green-500 hover:bg-green-600 text-white border-green-500",
     selectedClassName: "!bg-green-600 !text-white !font-bold !shadow-lg !ring-2 !ring-green-300",
   },
-  OUT: {
-    label: "외출",
-    variant: "secondary" as const,
-    className: "bg-blue-500 hover:bg-blue-600 text-white border-blue-500",
-    selectedClassName: "!bg-blue-600 !text-white !font-bold !shadow-lg !ring-2 !ring-blue-300",
-  },
   LEAVE: {
     label: "외박",
     variant: "outline" as const,
-    className: "bg-purple-500 hover:bg-purple-600 text-white border-purple-500",
-    selectedClassName: "!bg-purple-600 !text-white !font-bold !shadow-lg !ring-2 !ring-purple-300",
+    className: "bg-yellow-500 hover:bg-yellow-600 text-white border-yellow-500",
+    selectedClassName: "!bg-yellow-600 !text-white !font-bold !shadow-lg !ring-2 !ring-yellow-300",
   },
   ABSENT: {
     label: "결석",
@@ -94,14 +88,12 @@ export const AttendanceStatusButtons = forwardRef<HTMLDivElement, AttendanceStat
             )}
             style={isSelected ? {
               backgroundColor: statusKey === 'PRESENT' ? '#16a34a' : 
-                              statusKey === 'OUT' ? '#2563eb' : 
-                              statusKey === 'LEAVE' ? '#9333ea' : '#dc2626',
+                              statusKey === 'LEAVE' ? '#eab308' : '#dc2626',
               color: 'white',
               fontWeight: 'bold',
               boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
               border: `2px solid ${statusKey === 'PRESENT' ? '#22c55e' : 
-                                  statusKey === 'OUT' ? '#3b82f6' : 
-                                  statusKey === 'LEAVE' ? '#a855f7' : '#ef4444'}`
+                                  statusKey === 'LEAVE' ? '#facc15' : '#ef4444'}`
             } : {}}
             onClick={() => handleStatusChange(statusKey)}
             disabled={disabled || isChanging}

--- a/components/rollcall/rollcall-checklist.tsx
+++ b/components/rollcall/rollcall-checklist.tsx
@@ -168,7 +168,7 @@ export function RollCallChecklist({
                 <TableHead>학번</TableHead>
                 <TableHead>호실</TableHead>
                 <TableHead>상태</TableHead>
-                <TableHead>출석 상태</TableHead>
+                <TableHead>출석 상태 변경</TableHead>
                 <TableHead>비고</TableHead>
                 <TableHead>저장</TableHead>
               </TableRow>
@@ -209,7 +209,7 @@ export function RollCallChecklist({
                         rollcall={rollcalls.find(r => r.studentId === student.id)}
                         onStatusChange={handleStatusChange}
                         disabled={rollcallData.saving}
-                        className="min-w-[200px]"
+                        className="min-w-[150px] max-w-[180px]"
                       />
                     </TableCell>
                     <TableCell>

--- a/components/rollcall/rollcall-checklist.tsx
+++ b/components/rollcall/rollcall-checklist.tsx
@@ -190,7 +190,6 @@ export function RollCallChecklist({
                         
                         const statusConfig = {
                           PRESENT: { variant: "default" as const, label: "재실" },
-                          OUT: { variant: "secondary" as const, label: "외출" },
                           LEAVE: { variant: "outline" as const, label: "외박" },
                           ABSENT: { variant: "destructive" as const, label: "결석" },
                         }

--- a/components/rollcall/room-grid-view.tsx
+++ b/components/rollcall/room-grid-view.tsx
@@ -214,31 +214,33 @@ export function RoomGridView({ rooms, students, rollcalls, selectedDate, onUpdat
                           checked={selectedStudents.includes(student.id)}
                           onCheckedChange={() => toggleStudentSelection(student.id)}
                         />
-                        <div>
-                          <div className="font-medium">{student.name}</div>
-                          <div className="text-sm text-muted-foreground">{student.studentNo}</div>
+                        <div className="flex items-center gap-2">
+                          <div>
+                            <div className="font-medium">{student.name}</div>
+                            <div className="text-sm text-muted-foreground">{student.studentNo}</div>
+                          </div>
+                          {(() => {
+                            const rollcall = getStudentRollcall(student.id)
+                            const currentStatus = rollcall?.status || (rollcall?.present ? "PRESENT" : "ABSENT")
+                            
+                            const statusConfig = {
+                              PRESENT: { variant: "default" as const, label: "재실" },
+                              LEAVE: { variant: "outline" as const, label: "외박" },
+                              ABSENT: { variant: "destructive" as const, label: "결석" },
+                            }
+                            
+                            const config = statusConfig[currentStatus as keyof typeof statusConfig] || statusConfig.PRESENT
+                            
+                            return (
+                              <Badge variant={config.variant}>
+                                {config.label}
+                              </Badge>
+                            )
+                          })()}
                         </div>
                       </div>
 
                       <div className="flex flex-col gap-2">
-                        {(() => {
-                          const rollcall = getStudentRollcall(student.id)
-                          const currentStatus = rollcall?.status || (rollcall?.present ? "PRESENT" : "ABSENT")
-                          
-                          const statusConfig = {
-                            PRESENT: { variant: "default" as const, label: "재실" },
-                            LEAVE: { variant: "outline" as const, label: "외박" },
-                            ABSENT: { variant: "destructive" as const, label: "결석" },
-                          }
-                          
-                          const config = statusConfig[currentStatus as keyof typeof statusConfig] || statusConfig.PRESENT
-                          
-                          return (
-                            <Badge variant={config.variant}>
-                              {config.label}
-                            </Badge>
-                          )
-                        })()}
                         <AttendanceStatusButtons
                           student={student}
                           rollcall={getStudentRollcall(student.id)}

--- a/components/rollcall/room-grid-view.tsx
+++ b/components/rollcall/room-grid-view.tsx
@@ -227,7 +227,6 @@ export function RoomGridView({ rooms, students, rollcalls, selectedDate, onUpdat
                           
                           const statusConfig = {
                             PRESENT: { variant: "default" as const, label: "재실" },
-                            OUT: { variant: "secondary" as const, label: "외출" },
                             LEAVE: { variant: "outline" as const, label: "외박" },
                             ABSENT: { variant: "destructive" as const, label: "결석" },
                           }
@@ -305,6 +304,22 @@ export function RoomGridView({ rooms, students, rollcalls, selectedDate, onUpdat
                 </Button>
               </div>
             )}
+
+            {/* 저장 버튼 */}
+            <div className="flex justify-center pt-4 border-t">
+              <Button
+                onClick={() => {
+                  console.log("저장 버튼 클릭됨")
+                  toast.success("저장되었습니다.", {
+                    description: "학생 출석 정보가 저장되었습니다.",
+                    duration: 3000,
+                  })
+                }}
+                className="px-8"
+              >
+                저장
+              </Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/components/rollcall/room-grid-view.tsx
+++ b/components/rollcall/room-grid-view.tsx
@@ -307,19 +307,20 @@ export function RoomGridView({ rooms, students, rollcalls, selectedDate, onUpdat
               </div>
             )}
 
-            {/* 저장 버튼 */}
+            {/* 저장 및 닫기 버튼 */}
             <div className="flex justify-center pt-4 border-t">
               <Button
                 onClick={() => {
-                  console.log("저장 버튼 클릭됨")
+                  console.log("저장 및 닫기 버튼 클릭됨")
                   toast.success("저장되었습니다.", {
                     description: "학생 출석 정보가 저장되었습니다.",
                     duration: 3000,
                   })
+                  setSelectedRoom(null)
                 }}
                 className="px-8"
               >
-                저장
+                저장 및 닫기
               </Button>
             </div>
           </div>

--- a/hooks/use-rollcalls.ts
+++ b/hooks/use-rollcalls.ts
@@ -35,7 +35,7 @@ export function useRollcalls(params: RollcallQuery = {}) {
     }
   }
 
-  const mutate = async (rollcallData: Partial<Rollcall> & { date: string; studentId: number; present: boolean; status?: "PRESENT" | "OUT" | "LEAVE" | "ABSENT" }) => {
+  const mutate = async (rollcallData: Partial<Rollcall> & { date: string; studentId: number; present: boolean; status?: "PRESENT" | "LEAVE" | "ABSENT" }) => {
     try {
       console.log("mutate 호출됨:", rollcallData)
       const existingIndex = data.findIndex(

--- a/hooks/use-rollcalls.ts
+++ b/hooks/use-rollcalls.ts
@@ -2,10 +2,10 @@
 
 import { useState, useEffect } from "react"
 import { mockRollcalls } from "@/lib/mock-data"
-import type { RollCall, RollcallQuery } from "@/lib/types"
+import type { Rollcall, RollcallQuery } from "@/lib/types"
 
 export function useRollcalls(params: RollcallQuery = {}) {
-  const [data, setData] = useState<RollCall[]>([])
+  const [data, setData] = useState<Rollcall[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -35,29 +35,40 @@ export function useRollcalls(params: RollcallQuery = {}) {
     }
   }
 
-  const mutate = async (rollcallData: Partial<RollCall> & { date: string; studentId: number; present: boolean }) => {
+  const mutate = async (rollcallData: Partial<Rollcall> & { date: string; studentId: number; present: boolean; status?: "PRESENT" | "OUT" | "LEAVE" | "ABSENT" }) => {
     try {
+      console.log("mutate 호출됨:", rollcallData)
       const existingIndex = data.findIndex(
         (r) => r.studentId === rollcallData.studentId && r.date === rollcallData.date,
       )
+
+      console.log("기존 인덱스:", existingIndex)
 
       if (existingIndex >= 0) {
         // 기존 점호 기록 업데이트
         const updatedData = [...data]
         updatedData[existingIndex] = { ...updatedData[existingIndex], ...rollcallData }
+        console.log("기존 기록 업데이트:", updatedData[existingIndex])
         setData(updatedData)
+        console.log("setData 호출됨, 새로운 데이터:", updatedData)
       } else {
         // 새 점호 기록 추가
-        const newRollcall: RollCall = {
+        const newRollcall: Rollcall = {
           id: Math.max(...data.map((r) => r.id), 0) + 1,
           studentId: rollcallData.studentId,
+          roomId: rollcallData.roomId,
           date: rollcallData.date,
           present: rollcallData.present,
+          status: rollcallData.status,
           note: rollcallData.note || "",
         }
-        setData([...data, newRollcall])
+        console.log("새 기록 추가:", newRollcall)
+        const newData = [...data, newRollcall]
+        setData(newData)
+        console.log("setData 호출됨, 새로운 데이터:", newData)
       }
     } catch (err) {
+      console.error("mutate 에러:", err)
       throw err
     }
   }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001/api"
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001/"
 
 console.warn("API_BASE_URL:", API_BASE)
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,7 @@ export interface Rollcall {
   roomId: number
   studentId: number
   present: boolean
-  status?: "PRESENT" | "OUT" | "LEAVE" | "ABSENT"
+  status?: "PRESENT" | "LEAVE" | "ABSENT"
   checkedAt?: string
   checker?: string
   note?: string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,7 @@ export interface Rollcall {
   roomId: number
   studentId: number
   present: boolean
+  status?: "PRESENT" | "OUT" | "LEAVE" | "ABSENT"
   checkedAt?: string
   checker?: string
   note?: string


### PR DESCRIPTION
## ✨ 변경 사항
- 학생 재실 상태 선택 UI를 라디오 버튼 그룹으로 변경
- 상태별 색상 강조 (재실=초록, 외박=노랑, 결석=빨강)
- 상태 선택 시 즉시 반영되도록 구현

## 🖼️ 스크린샷
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/943341a3-c810-499a-a5a7-50881e4805a7" />
<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/beb435ad-d978-4595-b3b7-eddfe6aaed25" />


## ✅ 테스트 방법
1. `/rollcall` 페이지 접속
2. 각 호실 눌러서 모달 창 열기
3. 학생 상태를 각각 클릭해 변경
4. 저장 및 닫기 버튼 눌러서 닫기
