### PR TITLE
feat: 공지사항 작성 API 연결

### DIFF
--- a/app/notices/page.tsx
+++ b/app/notices/page.tsx
@@ -156,7 +156,7 @@ export default function NoticesPage() {
                       htmlFor="is_important"
                       className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     >
-                      중요공지로 설정
+                      중요공지
                     </Label>
                   </div>
 

--- a/hooks/use-notices.ts
+++ b/hooks/use-notices.ts
@@ -34,21 +34,11 @@ export function useNotices(params: NoticeQuery = {}) {
 
   const mutate = async (noticeData: {
     title: string;
-    body: string;
-    target: "ALL" | "FLOOR" | "ROOM";
-    floor?: number;
-    roomId?: number;
+    content: string;
+    is_important: boolean;
   }) => {
-    // POST API가 구현되지 않았으므로 로컬 상태만 업데이트
     try {
-      const newNotice: Notice = {
-        id: Math.max(...data.map((n) => n.id), 0) + 1,
-        title: noticeData.title,
-        content: noticeData.body,
-        date: new Date().toISOString().split("T")[0],
-        is_important: false,
-      };
-
+      const newNotice = await api.notices.create(noticeData);
       setData((prevData) => [newNotice, ...prevData]);
     } catch (err) {
       throw err;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -72,6 +72,8 @@ function apiDelete<T>(path: string) {
 export const noticesApi = {
   getAll: () => apiGet<Notice[]>("/notices"),
   getById: (id: number) => apiGet<Notice>(`/notices/${id}`),
+  create: (data: { title: string; content: string; is_important: boolean }) =>
+    apiPost<Notice>("/notice", data),
 };
 
 export const api = {


### PR DESCRIPTION
## 변경 사항
- 클라이언트 세션 저장 로직을 제거하고 실제 서버 API 호출로 변경
- `/notice` 엔드포인트로 POST 요청을 보내도록 수정

## 수정된 파일
- `lib/api.ts`: 공지사항 생성 POST API 엔드포인트 추가
- `hooks/use-notices.ts`: 클라이언트 세션 저장 로직 삭제 및 서버 API 호출로 변경

## API 요청 형식
```json
{
  "title": "공지 제목",
  "content": "공지 내용",
  "is_important": boolean
}
```